### PR TITLE
Undefined name 'ext' in xuexi/model.py

### DIFF
--- a/xuexi/model.py
+++ b/xuexi/model.py
@@ -191,9 +191,6 @@ class Model():
         logger.info(f'JSON数据{len(datas)}条成功导出{path}')
         return True
 
-
-
-
     def _from_json(self, path, catagory='挑战题 单选题 多选题 填空题'):
         if path.exists():
             with open(path,'r',encoding='utf-8') as fp:
@@ -229,8 +226,6 @@ class Model():
             
         return 0
 
-
-
     def _to_xls(self, path, catagory='挑战题 单选题 多选题 填空题'):
         from .common import xlser
         data = self.query(catagory=catagory)
@@ -240,17 +235,14 @@ class Model():
     def upload(self, path, catagory='挑战题 单选题 多选题 填空题'):
         if '.json' == path.suffix:
             self._from_json(path, catagory)
-        elif '.xls' == path.suffix or '.xlsx' == path.suffix:
-            pass
-        else:
-            logger.info(f'不被支持的文件类型: {ext}')
-
+        elif path.suffix not in ('.xls', '.xlsx'):
+            logger.info(f'不被支持的文件类型: {path.suffix}')
     
     def download(self, path, catagory='挑战题 单选题 多选题 填空题'):
         ext = path.suffix
         if '.json' == ext:
             self._to_json(path, catagory)
-        elif '.xls' == ext or '.xlsx' == ext:
+        elif ext in ('.xls', '.xlsx'):
             self._to_xls(path, catagory)
         elif '.md' == ext:
             self._to_md(path, catagory)


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/kessil/AutoXue on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./xuexi/model.py:246:57: F821 undefined name 'ext'
            logger.info(f'不被支持的文件类型: {ext}')
                                                        ^
1     F821 undefined name 'ext'
1
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree